### PR TITLE
Improve README formatting and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Or better 👉 [try it yourself](https://ada.universaldata.io)
 
 ### Docker installation
 
-```
+```bash
 docker-compose up -d
 ```
 
 ### Manual installation
 
-#### Backend Setup (in `/service` directory)
+#### Backend Setup (in [`/service`](/service) directory)
 
 1. **Install Dependencies**:
 
@@ -62,17 +62,17 @@ export ANTHROPIC_API_KEY=<Your_Anthropic_API_Key>
    bash run.sh
    ```
 
-#### Frontend Setup (in `/view` directory)
+#### Frontend Setup (in [`/view`](/view) directory)
 
 Install Dependencies
 
-```
+```bash
 yarn
 ```
 
 Run the front-end
 
-```
+```bash
 yarn dev
 ```
 
@@ -80,7 +80,7 @@ After completing the steps, open your browser and visit: [http://localhost:5173]
 
 ## Privacy & Safety
 
-We have developed built-in features to protect privacy and insure safety
+We have developed built-in features to protect privacy and ensure safety
 
 - **Preview only:** Model only have preview of the requested data
 - **“Privacy protection”:** hide fields about name, location


### PR DESCRIPTION
This PR makes several improvements to the README:

- Add language annotations to code blocks for better syntax highlighting
- Fix typo: "insure" -> "ensure" in the Privacy & Safety section
- Convert directory references (`/service` and `//view`) to clickable links

These changes make the documentation more polished and easier to navigate.